### PR TITLE
[Issues-2] Add support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:16 as AppBuilder
+
+ENV CI=true
+
+WORKDIR /usr/src/app
+
+RUN npm install --global lerna
+
+COPY ./lerna.json ./
+COPY ./package.json ./
+COPY ./package-lock.json ./
+COPY ./packages ./packages
+
+RUN npx lerna bootstrap
+RUN npm install
+RUN npm run release
+RUN npx lerna link
+
+# Final Setup
+FROM node:16 
+
+WORKDIR /app
+
+ENV DEBUG=*
+ENV USE_STATIC_ASSETS=true
+
+COPY --from=AppBuilder ./usr/src/app/ ./
+COPY --from=AppBuilder ./usr/src/app/packages/web-app/build ./packages/web-api/build/website
+
+WORKDIR packages/web-api
+
+EXPOSE 3030
+
+CMD ["node", "build/src/index.js"]

--- a/packages/web-api/src/app.ts
+++ b/packages/web-api/src/app.ts
@@ -5,6 +5,7 @@ import * as winston from 'winston';
 import * as expressWinston from 'express-winston';
 import cors from 'cors';
 import debug from 'debug';
+import path from 'path';
 import { InversifyContainer } from 'utils';
 import { CommonRoutesConfig } from './routes/CommonRoutesConfig';
 
@@ -65,6 +66,17 @@ export class SaloonApplication {
         debugLog(`Configuring Route: ${currentRoute.getName()}`);
         currentRoute.configureRoutes();
       });
+
+      if (process.env.USE_STATIC_ASSETS) {
+        const staticAssetsPath = path.join('build/website');
+        app.use(express.static(staticAssetsPath));
+    
+        app.get('*', (req: express.Request, res: express.Response) => {
+          const resolvedPath = path.resolve(staticAssetsPath, 'index.html');
+          debugLog(`ResolvedPath: ${resolvedPath}`);
+          res.sendFile(resolvedPath);
+        });
+      }
     });
   }
 }


### PR DESCRIPTION
### Overview

Before we onboard with our CloudProvider, let's first prepare Docker so we can have everything distributed a single file.

### Issues

* #2 

### Testing Done

* `docker build -t saloon-app:1.0.0 .`
* `docker run -p 3030:3030 saloon-app:1.0.0`
* Manual testing